### PR TITLE
Typo in README and fix in imports and stylistic changes in main.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Easy Recipes bot
 
-Just write down your ingredients and this bot instantly finds matching recipes!
+Just write down your ingredients and this bot instantly finds the matching recipes!
 
 This telegram bot recommends easy recipes in Azerbaijani using ingredients you already have in the kitchen.
 

--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 import warnings
-warnings.filterwarnings('ignore')
 from similiarity import compare_txt
 import time
-TOKEN = 'your token'
-import telebots
+import telebot
 from telebot import types
 
+warnings.filterwarnings('ignore')
+TOKEN = 'your token'
 
 bot = telebot.TeleBot(TOKEN)
 print(bot)


### PR DESCRIPTION
 - Fixed a typo in README file
 - There was an import ```import telebots``` which should be ```import telebot``` in main.py
 - Some stylistic changes in main.py (grouping imports together)